### PR TITLE
Fix homepage URL in gemspec

### DIFF
--- a/enumerator-parallel.gemspec
+++ b/enumerator-parallel.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{ Simple wrapper between enumerator and parallel. }
   spec.description   = %q{ Simple wrapper between enumerator and parallel. }
-  spec.homepage      = "https://github.com/gogotanaka/parallel-enumerable"
+  spec.homepage      = "https://github.com/gogotanaka/enumerator-parallel"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
I noticed that homepage URL is incorrect.

And module name in `./lib/enumerator-parallel/version.rb` also seems strange, but I didn't touch it.

``` rb
module ParallelEnumerable
  VERSION = "0.1.1"
end
```

Thank you for this cool gem :gem: 
